### PR TITLE
Provide exc_info to start_response() when handling exceptions

### DIFF
--- a/bottle.py
+++ b/bottle.py
@@ -874,6 +874,7 @@ class Bottle(object):
             if not self.catchall: raise
             stacktrace = format_exc()
             environ['wsgi.errors'].write(stacktrace)
+            environ['bottle.exc_info'] = sys.exc_info()
             return HTTPError(500, "Internal Server Error", _e(), stacktrace)
 
     def _cast(self, out, peek=None):
@@ -950,6 +951,7 @@ class Bottle(object):
 
     def wsgi(self, environ, start_response):
         """ The bottle WSGI-interface. """
+        provided_exc_info = False
         try:
             out = self._cast(self._handle(environ))
             # rfc2616 section 4.3
@@ -957,11 +959,16 @@ class Bottle(object):
             or environ['REQUEST_METHOD'] == 'HEAD':
                 if hasattr(out, 'close'): out.close()
                 out = []
-            start_response(response._status_line, response.headerlist)
+            exc_info = environ.get('bottle.exc_info')
+            if exc_info is not None:
+                del environ['bottle.exc_info']
+                provided_exc_info = True
+            start_response(response._status_line, response.headerlist, exc_info)
             return out
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception:
+            if provided_exc_info: raise
             if not self.catchall: raise
             err = '<h1>Critical error while processing request: %s</h1>' \
                   % html_escape(environ.get('PATH_INFO', '/'))

--- a/test/tools.py
+++ b/test/tools.py
@@ -54,7 +54,7 @@ class ServerTestBase(unittest.TestCase):
 
     def urlopen(self, path, method='GET', post='', env=None):
         result = {'code':0, 'status':'error', 'header':{}, 'body':tob('')}
-        def start_response(status, header):
+        def start_response(status, header, exc_info=None):
             result['code'] = int(status.split()[0])
             result['status'] = status.split(None, 1)[-1]
             for name, value in header:


### PR DESCRIPTION
Recommended by pep-3333 to enable middleware to provide exception handling
services, e.g. custom exception logging.

See https://www.python.org/dev/peps/pep-3333/#error-handling

Note that the exc_info is temporarily stored in the environ to pass it up
from _handler() to wsgi(), where start_response() is called. There may be
a better way to do this, e.g. storing it in the response object.